### PR TITLE
Adjustments to suit const char *

### DIFF
--- a/DccExController.ino
+++ b/DccExController.ino
@@ -1203,7 +1203,7 @@ void loop() {
       witServiceLoop();
     } else {
       dccexProtocol.check();    // parse incoming messages
-      dccexProtocol.getLists(true, true, true, true);
+      dccexProtocol.getLists(true, true, true, false);
 
       setLastServerResponseTime(false);
 
@@ -1903,7 +1903,7 @@ void loadFunctionLabels(int multiThrottleIndex) {  // from Roster entry
   debug_println("loadFunctionLabels()");
   if (throttles[multiThrottleIndex]->getLocoCount() > 0) {
     for (int i=0; i<MAX_FUNCTIONS; i++) {
-      char* fName = throttles[multiThrottleIndex]->getFirst()->getLoco()->getFunctionName(i);
+      const char* fName = throttles[multiThrottleIndex]->getFirst()->getLoco()->getFunctionName(i);
       bool fMomentary = throttles[multiThrottleIndex]->getFirst()->getLoco()->isFunctionMomentary(i);
       if (fName != nullptr) {
         // debug_print("loadFunctionLabels() "); 

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ lib_deps =
 	chris--a/Keypad@^3.1.1
 	igorantolic/Ai Esp32 Rotary Encoder@^1.4
 	olikraus/U8g2@^2.33.3
-	https://github.com/DCC-EX/DCCEXProtocol@^0.0.16
+	DCC-EX/DCCEXProtocol@^0.0.17
 ; lib_extra_dirs = 
 ; 	C:\Users\akers\Documents\GitHub\DCCEXProtocol
 monitor_speed = 115200


### PR DESCRIPTION
Line 1206 - change to `dccexProtocol.getLists(true, true, true, false);` to ignore turntables - not sure why but it creates an exception and reboot when you get the turntable lists, but I don't think you use them anyway?
Line 1906 just append const to it: `const char *fName = throttles[multiThrottleIndex]->getFirst()->getLoco()->getFunctionName(i);`